### PR TITLE
compute missing aspect property when the dimensions are given

### DIFF
--- a/src/layout.typ
+++ b/src/layout.typ
@@ -6,11 +6,13 @@
 	if auto not in node.size {
 		let (width, height) = node.size
 		node.radius = vector-len((width/2, height/2))
+		node.aspect = width/height
 		return node
 	}
 
 	if node.radius != auto {
 		node.size = (2*node.radius, 2*node.radius)
+		node.aspect = 1
 		return node
 	}
 


### PR DESCRIPTION
Example demonstrating the problem being solved:

```typ
#import "@preview/fletcher:0.4.0" as fletcher: node, edge

#fletcher.diagram({
  node((0, 0), width: 2em, height: 2em, stroke: 1pt, [a])
  edge("r")
  node((1, 0), shape: "rect", radius: 1em, stroke: 1pt, [a])
})
```

If both width and height are given, or radius is given but a rectangle shape is forced, then the `get-node-anchor` function needs the `aspect` property but it will be missing. This commit fixes the issue.