### PR TITLE
chore(formatting): removed trailing whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $)
 #import fletcher.shapes: diamond
 #set text(font: "Comic Neue", weight: 600)
 
-#fletcher.diagram( 
+#fletcher.diagram(
   node-stroke: 1pt,
   edge-stroke: 1pt,
   node((0,0), [Start], corner-radius: 2pt, extrude: (0, 3)),

--- a/build-readme.py
+++ b/build-readme.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
 
 	if len(args) == 0:
 		args = ['compile', 'build']
-		
+
 	if not set(args).issubset(['compile', 'build']):
 		print("""Usage:
   ./build-readme.py compile

--- a/docs/example-gallery/flowchart-trap.typ
+++ b/docs/example-gallery/flowchart-trap.typ
@@ -2,7 +2,7 @@
 #import fletcher.shapes: diamond
 #set text(font: "Comic Neue", weight: 600)
 
-#fletcher.diagram( 
+#fletcher.diagram(
 	node-stroke: 1pt/*<*/ + fg/*>*/,
 	edge-stroke: 1pt/*<*/ + fg/*>*/,
 	crossing-fill: bg, // hide

--- a/docs/manual.typ
+++ b/docs/manual.typ
@@ -187,42 +187,42 @@
 		node(c(0,1,0), $J P$)
 		node(c(1,1,0), $J P$)
 		node(c(2,1,0), $J X$)
-	  
+
 		node(c(0,0,1), $pi^*(T X times.circle T^* X)$)
 		node(c(1,0,1), $pi^*(T X times.circle T^* X)$)
 		node(c(2,0,1), $T X times.circle T^* X$)
 		node(c(0,1,1), $T P times.circle pi^* T^* X$)
 		node(c(1,1,1), $T P times.circle pi^* T^* X$)
 		node(c(2,1,1), $T_G P times.circle T^* X$)
-	  
+
 
 		// aways
 		edge(v000, c(0,0,1), $"Id"$, "->", bend: 0deg)
 		edge(c(1,0,0), c(1,0,1), $"Id"$, "->")
 		edge(c(2,0,0), c(2,0,1), $"Id"$, "->")
-	  
+
 		edge(c(0,1,0), c(0,1,1), $i_J$, "hook->")
 		edge(c(1,1,0), c(1,1,1), $i_J$, "hook->")
 		edge(c(2,1,0), c(2,1,1), $i_C$, "hook->")
-	  
+
 		// downs
 		edge(c(0,1,0), v000, $pi_J$, "=>", label-pos: 0.2)
 		edge(c(1,1,0), c(1,0,0), $pi_J$, "->", label-pos: 0.2)
 		edge(c(2,1,0), c(2,0,0), $pi_"CP"$, "->", label-pos: 0.2)
-	  
+
 		edge(c(0,1,1), c(0,0,1), $c_pi$, "..>", label-pos: 0.2)
 		edge(c(1,1,1), c(1,0,1), $c_pi$, "->", label-pos: 0.2)
 		edge(c(2,1,1), c(2,0,1), $overline(c)_pi$, "-||->", label-pos: 0.2)
-	  
+
 		// acrosses
 		edge(v000, c(1,0,0), $lambda_g$, "->")
 		edge(c(1,0,0), c(2,0,0), $pi^G=pi$, "->")
-	  
+
 		edge(c(0,0,1), c(1,0,1), $lambda_g times 1$, "..>", label-pos: 0.2)
 		edge(c(1,0,1), c(2,0,1), $pi^G$, "..>", label-pos: 0.2)
-	  
+
 		edge(c(0,1,0), c(1,1,0), $j lambda_g$, "->", label-pos: 0.7)
-	  
+
 		edge(c(0,1,1), c(1,1,1), $dif lambda_g times.circle (lambda_g times 1)$, "->")
 		edge(c(1,1,1), c(2,1,1), $pi^G$, "->")
 
@@ -351,7 +351,7 @@ Avoid importing everything with `*` as many internal functions are also exported
 		node-fill: gradient.radial(white, blue, center: (40%, 20%),
 		                           radius: 150%),
 		spacing: (15mm, 8mm),
-		node((0,0), [1], extrude: (0, -4)), // double stroke effect 
+		node((0,0), [1], extrude: (0, -4)), // double stroke effect
 		node((1,0), [2]),
 		node((2,-1), [3a]),
 		node((2,+1), [3b]),

--- a/docs/style.typ
+++ b/docs/style.typ
@@ -51,14 +51,14 @@
   if not inline { ",\n" } + ")"
 
   if fn.return-types != none {
-    " -> " 
+    " -> "
     fn.return-types.map(show-type).join(" ")
   }
 }
 
 
 
-// Create a parameter description block, containing name, type, description and optionally the default value. 
+// Create a parameter description block, containing name, type, description and optionally the default value.
 #let show-parameter-block(
   fn, name, types, content,
   show-default: false,
@@ -107,12 +107,12 @@
       #heading(raw(fn.name + "()"), level: style-args.first-heading-level + 1)
       #fn-label(fn.name)
     ]
-    
+
     #tidy.utilities.eval-docstring(fn.description, style-args)
 
     #show-parameter-list(fn)
   ]
-  
+
 
   for (name, info) in fn.args {
     let types = info.at("types", default: ())
@@ -123,9 +123,9 @@
       fn,
       name,
       types,
-      tidy.utilities.eval-docstring(description, style-args), 
+      tidy.utilities.eval-docstring(description, style-args),
       is-long: description.len() > 500, // approximate
-      show-default: "default" in info, 
+      show-default: "default" in info,
       default: info.at("default", default: none),
     )
   }
@@ -138,7 +138,7 @@
   var, style-args,
 ) = {
   if style-args.colors == auto { style-args.colors = colors }
-  let type = if "type" not in var { none } 
+  let type = if "type" not in var { none }
       else { show-type(var.type, style-args: style-args) }
 
   stack(dir: ltr, spacing: 1.2em,
@@ -148,7 +148,7 @@
     ],
     type
   )
-  
+
   eval-docstring(var.description, style-args)
   v(4.8em, weak: true)
 }

--- a/src/draw.typ
+++ b/src/draw.typ
@@ -122,7 +122,7 @@
 		if edge.label-anchor == auto {
 			edge.label-anchor = angle-to-anchor(θ - label-dir*90deg)
 		}
-	
+
 		let label-pos = vector.add(
 			vector.lerp(from, to, edge.label-pos),
 			vector-polar(edge.label-sep, θ + label-dir*90deg),
@@ -198,7 +198,7 @@
 			let θ = vector-angle(vector.sub(to, from))
 			edge.label-anchor = angle-to-anchor(θ - label-dir*90deg)
 		}
-		
+
 		let label-pos = vector.add(
 			center,
 			vector-polar(
@@ -269,7 +269,7 @@
 	if edge.corner-radius != none {
 		rounded-corners = range(1, θs.len()).map(calculate-rounded-corner)
 	}
-	
+
 	let lerp-scale(t, i) = {
 		let τ = t*n-segments - i
 		if 0 < τ and τ <= 1 or i == 0 and τ <= 0 or i == n-segments - 1 and 1 < τ { τ }
@@ -297,7 +297,7 @@
 
 			// add phantom marks to ensure segment joins are clean
 			if i > 0 {
-				let Δθ = θs.at(i) - θs.at(i - 1) 
+				let Δθ = θs.at(i) - θs.at(i - 1)
 				marks.push((
 					kind: "bar",
 					pos: 0,
@@ -407,7 +407,7 @@
 #let find-farthest-intersection(objects, target, callback) = {
 
 	if objects == none { return callback(target) }
-	
+
 	let node-name = "intersection-finder"
 	cetz.draw.hide(cetz.draw.intersections(node-name, objects))
 
@@ -436,7 +436,7 @@
 			callback((from-anchor, to-anchor))
 		})
 	})
-	
+
 }
 
 /// Get the anchor point around a node outline at a certain angle.
@@ -467,7 +467,7 @@
 		calc.max(0pt, node.size.at(0)/2*(1 - 1/μ))*calc.cos(θ),
 		calc.max(0pt, node.size.at(1)/2*(1 - μ/1))*calc.sin(θ),
 	)
-	
+
 }
 
 #let draw-anchored-line(edge, nodes, debug: 0) = {

--- a/src/layout.typ
+++ b/src/layout.typ
@@ -56,7 +56,7 @@
 
 /// Convert an array of rects with fractional positions into rects with integral
 /// positions.
-/// 
+///
 /// If a rect is centered at a factional position `floor(x) < x < ceil(x)`, it
 /// will be replaced by two new rects centered at `floor(x)` and `ceil(x)`. The
 /// total width of the original rect is split across the two new rects according

--- a/src/main.typ
+++ b/src/main.typ
@@ -435,7 +435,7 @@
 /// - marks (array): The marks (arrowheads) to draw along an edge's stroke. This
 ///   may be:
 ///
-///   - A shorthand string such as `"->"` or `"hook'-/->>"`. Specifically, 
+///   - A shorthand string such as `"->"` or `"hook'-/->>"`. Specifically,
 ///     shorthand strings are of the form $M_1 L M_2$ or $M_1 L M_2 L M_3$,
 ///     where
 ///     $
@@ -964,7 +964,7 @@
 ///   that nodes at adjacent grid points are at least this far apart (measured as
 ///   the space between their bounding boxes).
 ///
-///   Separate horizontal/vertical gutters can be specified with `(x, y)`. A 
+///   Separate horizontal/vertical gutters can be specified with `(x, y)`. A
 ///   single length `d` is short for `(d, d)`.
 ///
 /// - cell-size (length, pair of lengths): Minimum size of all rows and columns.
@@ -1118,7 +1118,7 @@
 	)
 
 	let (nodes, edges) = interpret-diagram-args(args)
-	
+
 	box(style(styles => {
 		let options = options
 
@@ -1134,7 +1134,7 @@
 		let grid = compute-grid(nodes, edges, options)
 
 		options.get-coord = grid.get-coord
-		
+
 		let (nodes, edges) = compute-final-coordinates(nodes, edges, grid, options)
 
 		render(grid, nodes, edges, options)

--- a/src/marks.typ
+++ b/src/marks.typ
@@ -63,7 +63,7 @@
 	cross: (size: 4, angle: 45deg),
 
 	hook: (size: 2.88, rim: 0.85, outer-len: 3),
-	
+
 )
 #{MARK_DEFAULTS.harpoon = MARK_DEFAULTS.head}
 
@@ -164,7 +164,7 @@
 	if type(mark) == str { mark = (kind: mark) }
 
 	mark = defaults + mark
-	
+
 	if mark.kind.at(-1) == "'" {
 		mark.flip = -mark.at("flip", default: +1)
 		mark.kind = mark.kind.slice(0, -1)

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -133,7 +133,7 @@
 ///
 /// The bend angle is the angle between chord of the arc (line connecting the
 /// points) and the tangent to the arc and the first point.
-/// 
+///
 /// Returns a dictionary containing:
 /// - `center`: the center of the arc's curvature
 /// - `radius`

--- a/test/test.typ
+++ b/test/test.typ
@@ -541,7 +541,7 @@ $ b^2 $
 
 = Axes configuration
 
-#for axes in ((ltr, btt), (ltr, ttb), (rtl, btt), (rtl, ttb)) {	
+#for axes in ((ltr, btt), (ltr, ttb), (rtl, btt), (rtl, ttb)) {
 	for axes in (axes, axes.rev()) {
 		diagram(
 			axes: axes,


### PR DESCRIPTION
For this next command was used:

```sh
rg -l0 '[ \t]+$' | xargs -0 sd '[ \t]+$' ''
```

I saved it as:

```sh
alias delete.trailing.whitespaces="rg -l0 '[ \t]+$' | xargs -0 sd '[ \t]+$' ''"
alias remove.trailing.whitespaces="rg -l0 '[ \t]+$' | xargs -0 sd '[ \t]+$' ''"
```

And then I can just write `trail` + Tab and zsh will autocomplete this alias for me.

P.S. Also this Neovim plugin by default removes trailing whitespaces from any formatted file: https://github.com/mhartington/formatter.nvim (I can't believe more tools/plugins don't do this).
