### PR TITLE
fix: now nodes appear normally with edge crossing

### DIFF
--- a/src/draw.typ
+++ b/src/draw.typ
@@ -747,10 +747,6 @@
 	debug: 0,
 ) = {
 
-	for node in nodes {
-		draw-node(node, debug: debug)
-	}
-
 	for edge in edges {
 		// find start/end notes to snap to (each can be none!)
 		let nodes = (
@@ -759,6 +755,10 @@
 			map-auto(edge.snap-to.at(1), edge.vertices.at(-1)),
 		).map(find-node-at.with(nodes))
 		draw-edge(edge, nodes, debug: debug)
+	}
+
+	for node in nodes {
+		draw-node(node, debug: debug)
 	}
 
 	if debug >= 1 {


### PR DESCRIPTION
Previously with `crossing: true` edge's background stroke was drawn on top of nodes which is not a desirable result:

![image](https://github.com/Jollywatt/typst-fletcher/assets/37143421/6fb52130-c425-4199-8e1b-4fa5a640da16)

Now the nodes are drawn after the edges, which resolves this problem.

![image](https://github.com/Jollywatt/typst-fletcher/assets/37143421/e803f572-db85-4737-a1a4-2f2ea448224b)

Now I noticed that with thick borders, the arrow is half missing. I think this is probably not a desired behavior and also should be fixed: the arrow should touch the node's border with just its tip so that the whole arrow head is visible.