### PR TITLE
docs: fix typos

### DIFF
--- a/docs/manual.typ
+++ b/docs/manual.typ
@@ -96,7 +96,7 @@
 
 #set raw(lang: "typc")
 #show raw.where(block: false): it => {
-	// if raw block is a funciton call, like `foo()`, make it a link
+	// if raw block is a function call, like `foo()`, make it a link
 	if it.text.match(regex("^[a-z-]+\(\)$")) == none { it }
 	else {
 		let l = label(it.text)
@@ -628,7 +628,7 @@ A label as an edge vertex is interpreted as the position of the node with that l
 ```)
 
 Node names are labels instead of strings (like in CeTZ) so that positional arguments to `edge()` are easier to disambiguate by their type.
-(Node labels are not inserted into the final outout, so they do not interfere with other labels in the document.)
+(Node labels are not inserted into the final output, so they do not interfere with other labels in the document.)
 
 == Edge types
 

--- a/src/draw.typ
+++ b/src/draw.typ
@@ -235,7 +235,7 @@
 	// Draw arc(s), one for each extrusion shift
 	for shift in edge.extrude {
 
-		// Adjust arc angles to accomodate for cap offsets
+		// Adjust arc angles to accommodate for cap offsets
 		let (δ-start, δ-stop) = cap-offsets(edge, shift)
 			.map(arclen => -bend-dir*arclen/radius*1rad)
 

--- a/src/marks.typ
+++ b/src/marks.typ
@@ -103,11 +103,11 @@
 }
 
 
-/// Draw a mark at a given potition and angle
+/// Draw a mark at a given position and angle
 ///
 /// - mark (dictionary): Mark object to draw. Must contain a `draw` entry.
 /// - stroke (stroke): Stroke style for the mark. The stroke's paint is used as
-///   the defauly fill style.
+///   the default fill style.
 /// - origin (point): Coordinate of the mark's origin (as defined by 
 ///   `tip-origin` or `tail-origin`).
 /// - angle (angle): Angle of the mark, `0deg` being $->$, counterclockwise.


### PR DESCRIPTION
Found via `codespell -S *.pdf -L ba,aways`