### PR TITLE
fix deprecated warning

### DIFF
--- a/src/diagram.typ
+++ b/src/diagram.typ
@@ -479,7 +479,7 @@
 
 	let (nodes, edges) = interpret-diagram-args(args)
 
-	box(style(styles => {
+	box(context {
 		let options = options
 
 		options.em-size = measure(h(1em)).width
@@ -489,7 +489,7 @@
 
 		let nodes = nodes.map(node => {
 			node = resolve-node-options(node, options)
-			node = measure-node-size(node, styles)
+			node = measure-node-size(node)
 			node
 		})
 		let edges = edges.map(edge => resolve-edge-options(edge, options))
@@ -541,5 +541,5 @@
 
 
 		render(grid, nodes, edges, options)
-	}))
+	})
 }

--- a/src/node.typ
+++ b/src/node.typ
@@ -335,7 +335,7 @@
 ///
 /// Widths and heights that are `auto` are determined by measuring the size of
 /// the node's label.
-#let measure-node-size(node, styles) = {
+#let measure-node-size(node) = {
 
 	// Width and height explicitly given
 	if auto not in node.size {
@@ -358,7 +358,7 @@
 			node.label,
 			width:  inner-size.at(0),
 			height: inner-size.at(1),
-		), styles)
+		))
 
 		// let (width, height) = node.inner-size
 		let radius = vector-len((width/2, height/2)) // circumcircle


### PR DESCRIPTION
Style is now accessed through a context and doesn't need to be passed to the measure function.