### PR TITLE
Bump CeTZ to 0.3.2

### DIFF
--- a/src/deps.typ
+++ b/src/deps.typ
@@ -1,1 +1,1 @@
-#import "@preview/cetz:0.3.1"
+#import "@preview/cetz:0.3.2"


### PR DESCRIPTION
This fixes build failures on typst 0.13.0 (current release candidate).

The driving reason for this change is that 0.13.0 removed the string equivalence between `int` (the type) and `"integer"` (the string), see [1] and [2]. CeTZ already accomodated for these breaking changes on 0.3.2 (https://github.com/cetz-package/cetz/commit/aa1270068e445b5cc5bff687e0daa67103041084).

[1]: https://typst.app/docs/reference/foundations/type/#compatibility
[2]: https://staging.typst.app/docs/changelog/0.13.0#removals