### PR TITLE
Add transfer function block diagram example

### DIFF
--- a/docs/gallery/11-transfer-function-block-diagram.svg
+++ b/docs/gallery/11-transfer-function-block-diagram.svg
@@ -1,0 +1,348 @@
+<svg class="typst-doc" viewBox="0 0 236.5921834646669 119.23191333858269" width="236.5921834646669pt" height="119.23191333858269pt" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:h5="http://www.w3.org/1999/xhtml">
+    <path class="typst-shape" fill="#ffffff" fill-rule="nonzero" d="M 0 0v 119.23191 h 236.59218 v -119.23191 Z "/>
+    <g>
+        <g class="typst-group" transform="matrix(1 0 0 1 14.173228346456693 14.173228346456693)">
+            <g>
+                <g class="typst-group">
+                    <g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" stroke-dashoffset="0" stroke-dasharray="3 3" transform="matrix(1 0 0 1 25.298456582727187 0)" d="M 0 0v 69.442726 h 135.5366 v -69.442726 h -135.5366 Z "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 14.59399450077529 19.75649995275591)" d="M 0 0h 22.79444 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 33.817673190765376 18.217409433774655)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 31.57806035119349 11.59449995275591)" d="M 0 0h 8.246 v 8.162 h -8.246 v -8.162 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 31.578060288201364 11.59449984251969)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 1.4000000000000001 6.181000000000001)">
+                                                            <use xlink:href="#g64BA89732A68419CD7BABCF3246524B0" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 44.55062324382982 19.756499952755973)" d="M 0 0h 9.294978 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 57.09776825695374 19.756499952755885)" d="M 0 0l 11.889289 0.000000000000025176711 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 65.41629674982052 18.217409433774655)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 55.47168503942007 53.44272829921261)" d="M 0 0c 0 0 0 0 0 0 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 55.471685039420066 21.382583422257568)" d="M 0 0l 0.0000000000000125883555 32.060146 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 55.47168503942007 53.44272829921261)" d="M 0 0h 14.662672 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 66.56359662383625 51.903637559758906)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 97.9073134488689 19.75649995275591)" d="M 0 0h 43.017735 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 137.35428660808822 18.217409433774655)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 135.27612381452417 11.59449995275591)" d="M 0 0h 8.246 v 8.162 h -8.246 v -8.162 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 135.27612375153208 11.59449984251969)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 1.4000000000000001 6.181000000000001)">
+                                                            <use xlink:href="#g64BA89732A68419CD7BABCF3246524B0" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 96.76001344886888 53.44272829921262)" d="M 0 0h 14.662672 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 107.85192490730081 51.903637559758906)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 144.83507007879012 53.44272829921261)" d="M 0 0c 0 0 0 0 0 0 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 130.6618418110736 53.44272829921261)" d="M 0 0m 0 0.0000000000000062941777 l 14.173228 -0.0000000000000062941777 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 144.83507007879012 23.66652274308306)" d="M 0 0m 0 29.776205 l 0.000000000000050353422 -29.776205 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 143.29597933933644 23.00866666141733)" d="M 0 0m 3.0781813 4.2286167 l -1.5390906 -4.2286167 l -1.5390906 4.2286167 "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 136.58907007879017 20.753710445816324)" d="M 0 0h 8.246 v 8.162 h -8.246 v -8.162 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 136.58907001579806 20.753710335580106)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 1.4000000000000001 6.181000000000001)">
+                                                            <use xlink:href="#g64BA89732A68419CD7BABCF3246524B0" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 148.08723666115262 19.756499952755973)" d="M 0 0h 27.072035 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 171.5885098521827 18.217409433774655)" d="M 0 0m 0 3.0781813 l 4.2286167 -1.5390906 l -4.2286167 -1.5390906 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 159.00829842524683 87.12895664566929)" d="M 0 0m 14.173228 0 l -14.173228 0.0000000000000125883555 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 144.83507007879012 87.1289566456693)" d="M 0 0m 14.173228 0 h -14.173228 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 121.37119173233344 87.1289566456693)" d="M 0 0m 23.463879 0 h -23.463879 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 83.77611338587677 87.1289566456693)" d="M 0 0m 37.595078 0 h -37.595078 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 55.47168503942007 87.1289566456693)" d="M 0 0m 28.304428 0 h -28.304428 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 41.29845669296339 87.1289566456693)" d="M 0 0c 0 0 0 0 0 0 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 41.29845669296339 87.1289566456693)" d="M 0 0m 14.173228 0 h -14.173228 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 41.29845669296339 53.44272829921261)" d="M 0 0m 0 33.68623 v -33.68623 "/>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 41.29845669296339 23.666522745627404)" d="M 0 0m 0 29.776205 l 0.0000000000000062941777 -29.776205 "/>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" transform="matrix(1 0 0 1 39.75936592201363 23.00866666141733)" d="M 0 0m 3.0781813 4.2286167 l -1.5390906 -4.2286167 l -1.5390906 4.2286167 "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 32.0524566929634 21.652891679080444)" d="M 0 0h 8.246 v 7.581 h -8.246 v -7.581 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 32.052456629971275 21.65289158459226)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 1.4000000000000001 6.181000000000001)">
+                                                            <use xlink:href="#g83D8C69A353238BCD80539399B724277" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 0 15.999999952755923)" d="M 0 0h 6.952 v 7.513 h -6.952 l -0.0000000000000015735444 -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 -0.00000012593425092595358 15.999999874015765)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 0.000000000049999829298746954 7.513)">
+                                                    <use xlink:href="#g7EC298D85392B7125BA9463D78B9B6F7" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 38.04628990031247 16.504333412073496)" d="M 0 0m 3.2521667 0 c -1.7944936 0 -3.2521667 1.4576732 -3.2521667 3.2521667 c 0 1.7944937 1.4576732 3.2521667 3.2521667 3.2521667 c 1.7944937 0 3.2521667 -1.4576731 3.2521667 -3.2521667 c 0 -1.7944936 -1.4576731 -3.2521667 -3.2521667 -3.2521667 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 41.29845669296339 19.756499952755924)" d="M 0 0Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 41.29845669296339 19.756499952755924)">
+                                    <g>
+                                        <g class="typst-group" transform="matrix(1 0 0 1 0 4.486999999999999)">
+                                            <g/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="#000000" fill-rule="nonzero" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 53.84560158010249 18.130416745406823)" d="M 0 0m 1.6260834 0 c -0.8972468 0 -1.6260834 0.7288366 -1.6260834 1.6260834 c 0 0.89724684 0.7288366 1.6260834 1.6260834 1.6260834 c 0.89724684 0 1.6260834 -0.72883654 1.6260834 -1.6260834 c 0 -0.8972468 -0.72883654 -1.6260834 -1.6260834 -1.6260834 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 55.47168503942007 19.756499952755924)" d="M 0 0Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 55.47168503942007 19.756499952755924)">
+                                    <g>
+                                        <g class="typst-group" transform="matrix(1 0 0 1 0 4.486999999999999)">
+                                            <g/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 69.64491344886888 10.000000078740166)" d="M 0 0v 19.513 h 28.2624 v -19.513 h -28.2624 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 75.64491338582678 15.999999952755923)" d="M 0 0h 16.2624 v 7.513 h -16.2624 v -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 75.64491329138859 15.999999874015765)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 0.00000000005000072447069752 7.513)">
+                                                    <use xlink:href="#g45F7DFED0FB044FFAF797A7C209AE7E2" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 9.009000000050001 10.23)">
+                                                    <use xlink:href="#g416C6052E21DAEDCACE1288AE6C2DA26" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 70.7922134488689 43.686228204724415)" d="M 0 0v 19.513 h 25.9678 v -19.513 h -25.9678 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 76.79221338582677 49.6862282992126)" d="M 0 0h 13.9678 v 7.513 h -13.9678 v -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 76.79221330713662 49.68622822047245)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 0.00000000005000072447069752 7.513)">
+                                                    <use xlink:href="#g45F7DFED0FB044FFAF797A7C209AE7E2" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 9.009000000050001 10.23)">
+                                                    <use xlink:href="#g8523A175C1663EBAE4D63786A864D5AE" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 112.08054181107362 43.686228204724415)" d="M 0 0v 19.513 h 18.5813 v -19.513 h -18.5813 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 118.08054173228345 49.6862282992126)" d="M 0 0h 6.5813 v 7.513 h -6.5813 v -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 118.08054171658542 49.68622822047245)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 1.10000000005 3.1789999999999994)">
+                                                    <use xlink:href="#g1E9DD640DF0C0A28FB5C7C0D8BB9447A" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 1.2155000000499998 11.308)">
+                                                    <use xlink:href="#g11A699E0B8E29C0B2FBD47589B52047" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                                <path class="typst-shape" fill="none" stroke="#000000" stroke-width="0.528" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 1.10000000005 4.763)" d="M 0 0h 4.3813 "/>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" stroke="#000000" stroke-width="1" stroke-linecap="butt" stroke-linejoin="miter" stroke-miterlimit="4" transform="matrix(1 0 0 1 141.58290331763527 16.504333412073496)" d="M 0 0m 3.2521667 0 c -1.7944936 0 -3.2521667 1.4576732 -3.2521667 3.2521667 c 0 1.7944937 1.4576732 3.2521667 3.2521667 3.2521667 c 1.7944937 0 3.2521667 -1.4576731 3.2521667 -3.2521667 c 0 -1.7944936 -1.4576731 -3.2521667 -3.2521667 -3.2521667 Z "/>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 144.83507007879012 19.756499952755924)" d="M 0 0Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 144.83507007879012 19.756499952755924)">
+                                    <g>
+                                        <g class="typst-group" transform="matrix(1 0 0 1 0 4.486999999999999)">
+                                            <g/>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 181.81712677165353 15.999999952755923)" d="M 0 0h 23.793 v 7.513 h -23.793 v -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 181.8171267244594 15.999999874015765)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 0.00000000005000072447069752 7.513)">
+                                                    <use xlink:href="#gD90D64B04C2ED3202F622542026407B1" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                                <g class="typst-text" transform="matrix(1 0 0 -1 9.42700000005 7.513)">
+                                                    <use xlink:href="#g86BFE8FC021DCED71F1A8FDE9712A789" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                    <use xlink:href="#gE508B67E2B43291BF66C077C087EE7E8" x="3.0580000000000003" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                    <use xlink:href="#gCDAB0B2BB68006B1545586F3F41D592E" x="11.308" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                        <path class="typst-shape" fill="none" transform="matrix(1 0 0 1 179.1815267716535 83.3724566456693)" d="M 0 0h 29.0642 v 7.513 h -29.0642 v -7.513 Z "/>
+                        <g class="typst-group">
+                            <g>
+                                <g class="typst-group" transform="matrix(1 0 0 1 179.18152675595547 83.37245656692915)">
+                                    <g>
+                                        <g class="typst-group">
+                                            <g>
+                                                <g class="typst-group">
+                                                    <g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 0.00000000005000072447069752 7.513)">
+                                                            <use xlink:href="#g7EC298D85392B7125BA9463D78B9B6F7" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 6.8420000000500005 10.23)">
+                                                            <use xlink:href="#g43F22C6AC196D8C356787222CA88C23B" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 9.95280000005 10.23)">
+                                                            <use xlink:href="#g5960B0E15C69E424813E6089B44788B1" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 15.38900000005 10.23)">
+                                                            <use xlink:href="#g4585E24764C8C28C039C76E71B0D243" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 19.92430000005 10.23)">
+                                                            <use xlink:href="#gFDC3555CD3B26F303CE06BA2D72AED4F" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                        <g class="typst-text" transform="matrix(1 0 0 -1 25.12180000005 10.23)">
+                                                            <use xlink:href="#g88B53BDDE719A60CE8E8FF27600D6B11" x="0" y="0" fill="#000000" fill-rule="nonzero"/>
+                                                        </g>
+                                                    </g>
+                                                </g>
+                                            </g>
+                                        </g>
+                                    </g>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <defs id="glyph">
+        <symbol id="g64BA89732A68419CD7BABCF3246524B0" overflow="visible">
+            <path d="M 0 0m 4.886 1.9180001 h -1.9950001 v 1.995 c 0 0.11199999 -0.055999994 0.16800022 -0.16799998 0.16800022 c -0.11199999 0 -0.16799998 -0.056000233 -0.16799998 -0.16800022 v -1.995 h -1.9950001 c -0.11199999 0 -0.16799998 -0.055999994 -0.16799998 -0.1680001 c 0 -0.11199999 0.055999994 -0.16799998 0.16799998 -0.16799998 h 1.9950001 v -1.995 c 0 -0.11200002 0.055999994 -0.16800001 0.16799998 -0.16800001 c 0.11199999 0 0.16799998 0.055999994 0.16799998 0.16800001 v 1.995 h 1.9950001 c 0.11199999 0 0.16800022 0.055999994 0.16800022 0.16799998 c 0 0.09100008 -0.07700014 0.1680001 -0.16800022 0.1680001 Z "/>
+        </symbol>
+        <symbol id="g83D8C69A353238BCD80539399B724277" overflow="visible">
+            <path d="M 0 0m 4.886 1.8900001 h -4.326 c -0.11199999 0 -0.16799998 -0.049000025 -0.16799998 -0.1400001 c 0 -0.09099996 0.055999994 -0.13999999 0.16799998 -0.13999999 h 4.326 c 0.11199999 0 0.16800022 0.049000025 0.16800022 0.13999999 c 0 0.08400011 -0.08400011 0.1400001 -0.16800022 0.1400001 Z "/>
+        </symbol>
+        <symbol id="g7EC298D85392B7125BA9463D78B9B6F7" overflow="visible">
+            <path d="M 0 0m 5.555 4.301 c 0 -0.12100029 0.04400015 -0.23099995 0.13199997 -0.3080001 c 0.2750001 -0.23099995 0.40700006 -0.53900003 0.40700006 -0.9130001 c 0 -0.14299989 -0.01099968 -0.27499986 -0.043999672 -0.3959999 c -0.22000027 -0.83599997 -0.80300045 -1.936 -1.6940002 -1.936 c -0.572 0 -0.91299987 0.30799997 -1.023 0.9239999 c 0.14300013 0.29700005 0.25300002 0.605 0.32999992 0.9460001 c 0.03300023 0.12100005 0.04400015 0.22000003 0.04400015 0.286 c 0 0.22000003 -0.08800006 0.32999992 -0.25300002 0.32999992 c -0.41799998 0 -0.5280001 -1.056 -0.54999995 -1.518 c -0.40700006 -0.6489999 -0.8800001 -0.96799994 -1.4410001 -0.96799994 c -0.60499996 0 -0.90199995 0.39600003 -0.90199995 1.1769999 c 0 0.22000003 0.032999992 0.45099998 0.088 0.6930001 c 0.12099999 0.48399997 0.44 1.089 0.95699996 1.8039999 c 0.04400003 0.05499983 0.065999985 0.11000013 0.065999985 0.16499996 c 0 0.14300013 -0.0769999 0.22000027 -0.24199998 0.22000027 c -0.0769999 0 -0.15399992 -0.032999992 -0.21999991 -0.11000013 c -0.53900003 -0.737 -1.067 -2.035 -1.067 -3.2340002 c 0 -1.056 0.39599997 -1.584 1.188 -1.584 c 0.627 0 1.166 0.363 1.639 1.0780001 c 0.15400004 -0.71500003 0.572 -1.0780001 1.2429998 -1.0780001 c 0.3630004 0 0.704 0.143 1.0120001 0.429 c 0.5170002 0.484 0.90199995 1.2540001 1.1659999 2.31 c 0.16499996 0.671 0.25300026 1.144 0.25300026 1.441 c 0 0.31899977 -0.07700014 0.5500002 -0.23099995 0.69299984 c -0.07700014 0.07700014 -0.17600012 0.11000013 -0.2750001 0.11000013 c -0.28600025 0 -0.5830002 -0.2750001 -0.5830002 -0.5609999 Z "/>
+        </symbol>
+        <symbol id="g45F7DFED0FB044FFAF797A7C209AE7E2" overflow="visible">
+            <path d="M 0 0m 8.844 7.48 c -0.23099995 0 -0.9790001 0.032999992 -1.21 0.032999992 c -0.16499996 0 -0.25299978 -0.08799982 -0.25299978 -0.26399994 c 0 -0.0880003 0.07700014 -0.14300013 0.23099995 -0.17600012 c 0.1539998 -0.032999992 0.2420001 -0.08799982 0.2420001 -0.16499996 c 0 -0.12099981 -0.12100029 -0.28600025 -0.37400007 -0.47300005 l -4.158 -3.179 l 0.8470001 3.3659997 c 0.05499983 0.23100042 0.1539998 0.37400007 0.29699993 0.42900038 c 0.065999985 0.021999836 0.25299978 0.032999992 0.572 0.032999992 c 0.28599977 0 0.41799974 0 0.41799974 0.26399994 c 0 0.11000013 -0.065999985 0.16499996 -0.19799995 0.16499996 l -1.3969998 -0.032999992 l -1.408 0.032999992 c -0.17600012 0.011000156 -0.26400018 -0.07700014 -0.26400018 -0.25300026 c 0 -0.12099981 0.12100005 -0.17599964 0.36300015 -0.17599964 c 0.22000003 0 0.671 0.032999992 0.671 -0.14300013 c 0 -0.021999836 -0.011000156 -0.08799982 -0.04400015 -0.19799995 l -1.4629999 -5.841 c -0.054999948 -0.24200004 -0.16499996 -0.385 -0.32999992 -0.44 c -0.07700002 -0.022000015 -0.2750001 -0.033000022 -0.61600006 -0.033000022 c -0.24199998 0 -0.352 -0.021999985 -0.352 -0.253 c 0 -0.121 0.066000015 -0.176 0.20899999 -0.176 l 1.386 0.033 l 0.6930001 -0.011 c 0.12099981 0 0.58299994 -0.022 0.704 -0.022 c 0.17599988 0 0.26399994 0.088 0.26399994 0.264 c 0 0.110000014 -0.11000013 0.16499999 -0.34100008 0.16499999 c -0.45099998 0 -0.671 0.044 -0.671 0.14300004 c 0 0.054999948 0.032999992 0.21999997 0.09899998 0.47299993 l 0.42900014 1.6940001 l 1.573 1.2099998 l 1.243 -2.8709998 c 0.07700014 -0.18699998 0.12099981 -0.30799997 0.12099981 -0.36299998 c 0 -0.18699998 -0.17600012 -0.28599998 -0.5169997 -0.28599998 c -0.19799995 0 -0.28600025 -0.044 -0.28600025 -0.264 c 0 -0.10999999 0.065999985 -0.16499999 0.19799995 -0.16499999 c 0.2420001 0 1.0780001 0.033 1.3200002 0.033 c 0.20900011 0 0.86899996 -0.033 1.0780001 -0.033 c 0.15400028 0 0.23099995 0.088 0.23099995 0.264 c 0 0.09900001 -0.0880003 0.15399998 -0.25300026 0.16499999 c -0.45099974 0 -0.5609999 0.12100002 -0.7149997 0.46199998 l -1.5510001 3.5529997 c -0.011000156 0.055000305 -0.032999992 0.09899998 -0.04400015 0.13200045 l 2.2000003 1.6939998 c 0.53899956 0.41799974 1.0009995 0.671 1.375 0.7589998 c 0.26399994 0.04400015 0.6160002 0.032999992 0.6160002 0.31900024 c 0 0.11000013 -0.055000305 0.16499996 -0.16499996 0.16499996 c -0.15400028 0 -0.6160002 -0.032999992 -0.77000046 -0.032999992 Z "/>
+        </symbol>
+        <symbol id="g416C6052E21DAEDCACE1288AE6C2DA26" overflow="visible">
+            <path d="M 0 0m 1.7787 5.0589 c 0 -0.08470011 0.092399955 -0.1308999 0.28490007 -0.1308999 c 0.23869991 0 0.37730002 -0.015399933 0.41579986 -0.038499832 c 0.0076999664 -0.0076999664 0.0076999664 -0.030800343 0.0076999664 -0.05390024 l -1.0317999 -4.1734 c -0.03849995 -0.14629996 -0.08469999 -0.23869997 -0.14629996 -0.27719998 c -0.06159997 -0.03849998 -0.22329998 -0.053900003 -0.5005 -0.053900003 c -0.1771 0 -0.2618 -0.023099989 -0.2618 -0.20019999 c 0.023100019 -0.084699996 0.030799985 -0.1309 0.15399998 -0.1309 c 0.1771 0 0.8085 0.0308 0.98560005 0.0308 c 0.36960006 0 0.8469999 -0.0308 1.0163999 -0.0308 c 0.13090014 0 0.19250011 0.069299996 0.19250011 0.20019999 c 0 0.069299996 -0.023100138 0.10780001 -0.07700014 0.1155 c -0.08469987 0.0076999962 -0.1539998 0.0153999925 -0.20019984 0.0153999925 c -0.23870015 0.007700026 -0.43120003 -0.0076999962 -0.43120003 0.10010001 l 0.4697001 1.925 h 1.3552 c 0.5467 0 1.0625997 0.14630008 1.5476999 0.43120003 c 0.57749987 0.3311 0.86240005 0.7469001 0.86240005 1.2551 c 0 0.40040016 -0.19250011 0.71609974 -0.57750034 0.9393997 c -0.31570005 0.18480015 -0.69299984 0.27720022 -1.1241999 0.27720022 h -2.6641998 c -0.17710006 0 -0.2772001 -0.0230999 -0.2772001 -0.20020008 Z m 2.6873002 -0.1308999 c 0.7469001 0 1.1164999 -0.23869991 1.1164999 -0.7238002 c 0 -0.16939974 -0.038499832 -0.36959982 -0.10780001 -0.60059977 c -0.20020008 -0.62370014 -0.73150015 -0.93939996 -1.5939 -0.93939996 h -1.1781001 l 0.50820017 2.0251 c 0.06159997 0.23869991 0.053900003 0.23869991 0.36189985 0.23869991 Z "/>
+        </symbol>
+        <symbol id="g8523A175C1663EBAE4D63786A864D5AE" overflow="visible">
+            <path d="M 0 0m 4.1272 5.1128 c 0 0.10010004 -0.05390024 0.14629984 -0.15400004 0.14629984 c -0.32340002 0 -0.6853001 -0.038499832 -1.0164001 -0.030799866 l -0.5236001 0.0076999664 c -0.1000998 0 -0.42349982 0.0230999 -0.52359986 0.0230999 c -0.13090003 0 -0.1925 -0.069300175 -0.1925 -0.20020008 c 0 -0.0692997 0.023100019 -0.10780001 0.07700002 -0.11549997 c 0.08469999 -0.0076999664 0.15399992 -0.015399933 0.20019996 -0.015399933 c 0.27719986 -0.015399933 0.46969998 -0.0076999664 0.46969998 -0.092400074 c 0 -0.0230999 -0.0076999664 -0.07700014 -0.030800104 -0.1539998 l -1.0086999 -4.0425 c -0.023100019 -0.092400014 -0.046200037 -0.15400001 -0.06929994 -0.19250003 c -0.053900003 -0.07699999 -0.23870003 -0.1155 -0.5544001 -0.1155 c -0.1925 0 -0.30799997 0 -0.30799997 -0.1925 v -0.038499996 c 0.023100019 -0.069299996 0.069299996 -0.100099996 0.15399998 -0.100099996 c 0.1771 0 0.82390004 0.0308 1.0164001 0.0308 l 0.5236 -0.0077 c 0.10010004 0 0.42350006 -0.0231 0.5236001 -0.0231 c 0.1308999 0 0.19249988 0.069299996 0.19249988 0.20019999 c 0 0.08470002 -0.053900003 0.1232 -0.15400004 0.1309 c -0.20019984 0.007700026 -0.34649992 0.015400022 -0.44659996 0.015400022 c -0.06159997 0.0076999962 -0.14630008 0.03849998 -0.14630008 0.08469999 l 1.0395 4.1888 c 0.03850007 0.15400028 0.11549997 0.24639988 0.22329998 0.2849002 c 0.03850007 0.015399933 0.17710018 0.0230999 0.40040016 0.0230999 c 0.20790005 0 0.3080001 0.0230999 0.3080001 0.18480015 Z "/>
+        </symbol>
+        <symbol id="g1E9DD640DF0C0A28FB5C7C0D8BB9447A" overflow="visible">
+            <path d="M 0 0m 2.3331 5.1128 c -0.3311 -0.32340002 -0.8239001 -0.48510027 -1.4938002 -0.48510027 v -0.33879995 c 0.4543 0 0.81619996 0.069300175 1.0934 0.20020008 v -3.8346 c 0 -0.10010004 -0.0077000856 -0.16170001 -0.030800104 -0.1925 c -0.03849995 -0.08470002 -0.2694999 -0.13090003 -0.69299996 -0.13090003 h -0.3157 v -0.3311 l 1.3706 0.0308 l 1.3783002 -0.0308 v 0.3311 h -0.31570005 c -0.42350006 0 -0.6545 0.046200007 -0.70070004 0.13090003 c -0.015399933 0.030799985 -0.0230999 0.092399955 -0.0230999 0.1925 v 4.2118998 c 0 0.20790005 -0.030800104 0.24640036 -0.26950002 0.24640036 Z "/>
+        </symbol>
+        <symbol id="g11A699E0B8E29C0B2FBD47589B52047" overflow="visible">
+            <path d="M 0 0m 3.619 2.7104 c 0 0.47739983 -0.50049996 0.6852999 -1.0318 0.6852999 c -0.55439997 0 -0.9470999 -0.16170001 -1.1703999 -0.48510003 c -0.16939998 -0.23869991 -0.25410008 -0.45429993 -0.25410008 -0.64680004 c 0 -0.36189997 0.19250011 -0.6083 0.5775001 -0.7391999 c 0.06929994 -0.023100019 0.26180005 -0.06160009 0.5697999 -0.11550009 c 0.40810013 -0.0769999 0.61599994 -0.23099995 0.61599994 -0.46969992 c 0 -0.08470005 -0.030799866 -0.1771 -0.092399836 -0.29260004 c -0.16170001 -0.30029997 -0.50820017 -0.4543 -1.0318 -0.4543 c -0.42350006 0 -0.7084 0.092400014 -0.8547 0.26950002 c 0.20789999 0.03850001 0.39270002 0.21560001 0.39270002 0.4543 c 0 0.20789999 -0.10780001 0.30800003 -0.32340002 0.30800003 c -0.29259998 0 -0.46969998 -0.24640006 -0.46969998 -0.53900003 c 0 -0.539 0.63909996 -0.7623 1.2474 -0.7623 c 0.52359986 0 0.924 0.1232 1.2012 0.3619 c 0.31569982 0.26949996 0.46969986 0.5775 0.46969986 0.9163 c 0 0.47739995 -0.3541999 0.78540003 -1.0625999 0.91630006 c -0.13090014 0.030799866 -0.23099995 0.053900003 -0.30030012 0.06159997 c -0.26179993 0.046200037 -0.39269996 0.16170001 -0.39269996 0.34649992 c 0 0.08470011 0.030800104 0.16170001 0.08470011 0.24640012 c 0.14629996 0.23869991 0.4080999 0.3541999 0.7853999 0.3541999 c 0.32340002 0 0.5467 -0.0769999 0.6622 -0.23099995 c -0.19249988 -0.06159997 -0.29259992 -0.18479991 -0.29259992 -0.37730002 c 0 -0.17709994 0.092400074 -0.26950002 0.27719998 -0.26950002 c 0.23099995 0 0.39269996 0.20020008 0.39269996 0.46200013 Z "/>
+        </symbol>
+        <symbol id="gD90D64B04C2ED3202F622542026407B1" overflow="visible">
+            <path d="M 0 0m 5.467 7.337 c 0 0.12100029 -0.065999985 0.17600012 -0.20900011 0.17600012 l -1.4189999 -0.032999992 l -1.441 0.032999992 c -0.17600012 0.011000156 -0.26399994 -0.07700014 -0.26399994 -0.26399994 c 0 -0.11000013 0.12099981 -0.16499996 0.352 -0.16499996 c 0.4729998 0 0.704 -0.055000305 0.704 -0.15400028 c 0 -0.05499983 -0.011000156 -0.10999966 -0.022000074 -0.16499996 l -1.4629999 -5.863 c -0.055000067 -0.24200004 -0.16500008 -0.385 -0.33000004 -0.44 c -0.07700002 -0.022000015 -0.27499998 -0.033000022 -0.616 -0.033000022 c -0.275 0 -0.385 -0.011000007 -0.385 -0.264 c 0 -0.10999999 0.065999985 -0.16499999 0.20899999 -0.16499999 l 1.408 0.033 l 1.4520001 -0.033 c 0.17599988 -0.011 0.26399994 0.077 0.26399994 0.253 c 0 0.176 -0.13199997 0.176 -0.37400007 0.176 c -0.4289999 0 -0.6930001 -0.021999985 -0.6930001 0.15400001 c 0 0.055000007 0.011000156 0.13199997 0.04400015 0.24199998 l 1.4520001 5.797 c 0.05499983 0.23100042 0.16499996 0.37400007 0.32999992 0.42900038 c 0.076999664 0.021999836 0.2750001 0.032999992 0.6159997 0.032999992 c 0.26400042 0 0.38500023 0.01099968 0.38500023 0.25299978 Z "/>
+        </symbol>
+        <symbol id="g86BFE8FC021DCED71F1A8FDE9712A789" overflow="visible">
+            <path d="M 0 0m 2.563 -2.222 h -0.814 v 9.944 h 0.814 c 0.16499996 0 0.25300002 0.08799982 0.25300002 0.26399994 c 0 0.17599964 -0.08800006 0.26399994 -0.25300002 0.26399994 h -1.309 v -11 h 1.309 c 0.16499996 0 0.25300002 0.08800006 0.25300002 0.26399994 c 0 0.13199997 -0.12100005 0.26400018 -0.25300002 0.26400018 Z "/>
+        </symbol>
+        <symbol id="gE508B67E2B43291BF66C077C087EE7E8" overflow="visible">
+            <path d="M 0 0m 6.413 0.033 l 1.474 -0.033 v 0.429 h -0.2420001 c -0.2750001 0 -0.4619999 0.011000007 -0.53900003 0.033000022 c -0.16499996 0.055000007 -0.2750001 0.176 -0.34100008 0.36299998 l -2.354 6.809 c -0.043999672 0.14300013 -0.12099981 0.2420001 -0.28599977 0.2420001 c -0.14300013 0 -0.2420001 -0.07700014 -0.29699993 -0.2420001 l -2.255 -6.512 c -0.15399992 -0.45099998 -0.561 -0.69299996 -1.221 -0.704 v -0.41799998 l 1.155 0.033 l 1.287 -0.033 v 0.429 c -0.53900003 0 -0.8139999 0.16499999 -0.8139999 0.50600004 c 0 0.07699996 0.010999918 0.12099999 0.022000074 0.14299995 l 0.4949999 1.397 h 2.6179998 l 0.56100035 -1.6279999 c 0.021999836 -0.065999985 0.032999992 -0.110000014 0.032999992 -0.143 c 0 -0.18699998 -0.29699993 -0.275 -0.90199995 -0.275 v -0.429 c 0.4619999 0.033 1.0009999 0.044 1.606 0.033 Z m -2.618 6.226 l 1.1659999 -3.3549998 h -2.321 Z "/>
+        </symbol>
+        <symbol id="gCDAB0B2BB68006B1545586F3F41D592E" overflow="visible">
+            <path d="M 0 0m 0.495 -2.75 h 1.309 v 11 h -1.309 c -0.16500002 0 -0.25300002 -0.0880003 -0.25300002 -0.26399994 c 0 -0.17600012 0.087999985 -0.26399994 0.25300002 -0.26399994 h 0.814 v -9.944 h -0.814 c -0.16500002 0 -0.25300002 -0.08800006 -0.25300002 -0.26400018 c 0 -0.17599988 0.087999985 -0.26399994 0.25300002 -0.26399994 Z "/>
+        </symbol>
+        <symbol id="g43F22C6AC196D8C356787222CA88C23B" overflow="visible">
+            <path d="M 0 0m 2.5025 4.7817 c 0 0.18479967 -0.14630008 0.32340002 -0.3311 0.32340002 c -0.23100007 0 -0.45430005 -0.21560001 -0.45430005 -0.44659996 c 0 -0.18480015 0.14629996 -0.32340002 0.33109987 -0.32340002 c 0.23100019 0 0.45430017 0.21560001 0.45430017 0.44659996 Z m -1.0241001 -1.3629003 c -0.36189997 0 -0.6468 -0.18479991 -0.85469997 -0.55439997 c -0.17710003 -0.30799985 -0.26180002 -0.52359986 -0.26180002 -0.64680004 c 0 -0.08469987 0.053900003 -0.12319994 0.15400001 -0.12319994 c 0.08469999 0 0.13859999 0.046200037 0.16939998 0.13860011 c 0.1771 0.6083 0.43120003 0.90859985 0.77 0.90859985 c 0.10780001 0 0.16170001 -0.0769999 0.16170001 -0.23869991 c 0 -0.10010004 -0.07700002 -0.34649992 -0.23099995 -0.7469001 l -0.47740006 -1.2242999 c -0.046199977 -0.1232 -0.069299996 -0.231 -0.069299996 -0.3311 c 0 -0.4004 0.34649998 -0.6776 0.7469 -0.6776 c 0.36189997 0 0.6391001 0.1848 0.8469999 0.5621 c 0.17710018 0.308 0.26180005 0.5159 0.26180005 0.6314 c 0 0.08469999 -0.053900003 0.13090003 -0.15400004 0.13090003 c -0.0461998 -0.0077000856 -0.1000998 -0.046200037 -0.1539998 -0.12320006 c -0.007700205 -0.0076999664 -0.015400171 -0.023100019 -0.015400171 -0.030799985 c -0.17709994 -0.5929 -0.4311999 -0.89320004 -0.7622999 -0.89320004 c -0.10780001 0 -0.16170001 0.07699999 -0.16170001 0.231 c 0 0.1155 0.03849995 0.2772 0.12319994 0.47739998 l 0.6083001 1.5784999 c 0.030799866 0.08470011 0.046200037 0.16940022 0.046200037 0.25410008 c 0 0.40039992 -0.34650004 0.6775999 -0.7469001 0.6775999 Z "/>
+        </symbol>
+        <symbol id="g5960B0E15C69E424813E6089B44788B1" overflow="visible">
+            <path d="M 0 0m 1.2628 3.3957 c -0.25409997 0 -0.462 -0.13860011 -0.62369996 -0.42350006 c -0.10780001 -0.19249988 -0.19250003 -0.39269996 -0.24640003 -0.61599994 c -0.023099989 -0.08470011 -0.030799985 -0.1308999 -0.030799985 -0.14630008 c 0 -0.08469987 0.053900003 -0.1308999 0.16169998 -0.1308999 c 0.14630002 0 0.15400004 0.08470011 0.1925 0.24639988 c 0.13090003 0.53130007 0.30799997 0.8008001 0.53130007 0.8008001 c 0.14629996 0 0.2155999 -0.11549997 0.2155999 -0.34649992 c 0 -0.08470011 -0.03849995 -0.28489995 -0.12319994 -0.61599994 l -0.4081 -1.6478001 c -0.053900003 -0.20790002 -0.07700002 -0.31570002 -0.07700002 -0.32340002 c 0 -0.1771 0.10010004 -0.2695 0.29260004 -0.2695 c 0.14629996 0 0.25409997 0.0616 0.32340002 0.1848 c 0.023100019 0.0462 0.06929994 0.20789999 0.13859999 0.4774 l 0.16170001 0.67759997 c 0.092399955 0.36189997 0.14629996 0.56210005 0.16170001 0.6083 c 0.06159997 0.20020008 0.15399992 0.39269996 0.28489983 0.56980014 c 0.32340002 0.45429993 0.6930001 0.6852999 1.1165001 0.6852999 c 0.27719998 0 0.41579986 -0.16939998 0.41579986 -0.50049996 c 0 -0.30030012 -0.14629984 -0.83159995 -0.44659996 -1.6016 c -0.0769999 -0.20019996 -0.11549997 -0.33879995 -0.11549997 -0.42349994 c 0 -0.4158 0.33879995 -0.6776 0.75460005 -0.6776 c 0.36189985 0 0.6545 0.1848 0.86240005 0.5544 c 0.1770997 0.3157 0.2617998 0.52360004 0.2617998 0.6313999 c 0 0.08470011 -0.053899765 0.13090003 -0.1539998 0.13090003 c -0.05390024 -0.0076999664 -0.10780001 -0.046199918 -0.16170025 -0.12319994 c -0.0076999664 -0.0077000856 -0.0076999664 -0.023100019 -0.0076999664 -0.030799985 c -0.1770997 -0.59290004 -0.4389 -0.89320004 -0.77769995 -0.89320004 c -0.10780001 0 -0.16170001 0.07699999 -0.16170001 0.2387 c 0 0.10779998 0.06160021 0.308 0.17710018 0.6006 c 0.26950002 0.6853 0.40039992 1.1780999 0.40039992 1.4707 c 0 0.3541999 -0.12319994 0.6006 -0.36189985 0.7314999 c -0.19250011 0.10780001 -0.4158001 0.16170001 -0.65450025 0.16170001 c -0.50049996 0 -0.9239998 -0.21560001 -1.2628 -0.64680004 c -0.06929994 0.37730002 -0.40039992 0.64680004 -0.8392999 0.64680004 Z "/>
+        </symbol>
+        <symbol id="g4585E24764C8C28C039C76E71B0D243" overflow="visible">
+            <path d="M 0 0m 3.1185 3.3957 c -0.37730002 0 -0.7314999 -0.16939998 -1.0625999 -0.50819993 c -0.11550009 0.33879995 -0.3850001 0.50819993 -0.7931001 0.50819993 c -0.36189997 0 -0.6314 -0.28489995 -0.8162 -0.86240005 c -0.0616 -0.18479991 -0.092399985 -0.29259992 -0.092399985 -0.3311 c 0 -0.08469987 0.053900003 -0.1308999 0.16170001 -0.1308999 c 0.15399998 0 0.16170001 0.08469987 0.20019996 0.25409985 c 0.13090003 0.53130007 0.3003 0.7931001 0.5236 0.7931001 c 0.14630008 0 0.21560001 -0.11549997 0.21560001 -0.33879995 c 0 -0.08470011 -0.0076999664 -0.16170001 -0.023100019 -0.22329998 l -0.86239994 -3.4650002 c -0.053900003 -0.21560001 -0.069299996 -0.25409997 -0.3388 -0.25409997 c -0.16170001 0 -0.2387 -0.046200037 -0.2387 -0.18480003 c 0 -0.10010004 0.0462 -0.14630008 0.13859999 -0.14630008 c 0.1232 0 0.5236 0.030800104 0.6545 0.030800104 c 0.14630002 0 0.6468 -0.030800104 0.79310006 -0.030800104 c 0.12319994 0 0.18479991 0.069300056 0.18479991 0.20020008 c 0 0.08469999 -0.0769999 0.13090003 -0.23099995 0.13090003 c -0.22329998 0 -0.33879995 0.0230999 -0.33879995 0.06159997 c 0 0.0076999664 0.0076999664 0.046199918 0.0230999 0.10009992 l 0.32340002 1.309 c 0.17710006 -0.2695 0.4389 -0.40039998 0.77 -0.40039998 c 0.5236001 0 0.9856 0.2387 1.3937001 0.7084 c 0.39269972 0.4543 0.58519983 0.9471 0.58519983 1.4784 c 0 0.7161 -0.44659996 1.3013 -1.1703999 1.3013 Z m -0.0230999 -0.27719998 c 0.34649992 0 0.52359986 -0.23099995 0.52359986 -0.70070004 c 0 -0.4389 -0.23099995 -1.2166 -0.385 -1.5169 c -0.15400004 -0.3157 -0.5158999 -0.7238 -0.924 -0.7238 c -0.15400004 0 -0.28489995 0.046199992 -0.39269996 0.14629999 c -0.16939998 0.16170001 -0.25409997 0.3234 -0.25409997 0.4851 c 0 0.0153999925 0.0076999664 0.053900003 0.023100019 0.10780001 l 0.37730002 1.5246 c 0.33879995 0.45429993 0.6852999 0.6775999 1.0318 0.6775999 Z "/>
+        </symbol>
+        <symbol id="gFDC3555CD3B26F303CE06BA2D72AED4F" overflow="visible">
+            <path d="M 0 0m 4.0348 3.3187 c -0.30030012 0 -0.35420012 -0.22329998 -0.42350006 -0.48510003 l -0.39269996 -1.5708001 c -0.06929994 -0.2849 -0.10780001 -0.43119997 -0.11549997 -0.4389 c -0.25410008 -0.4235 -0.55439997 -0.6314 -0.89320016 -0.6314 c -0.33109987 0 -0.49279988 0.20019999 -0.49279988 0.6006 c 0 0.28489995 0.13859999 0.7931 0.42349994 1.5245999 c 0.06929994 0.18480015 0.10780001 0.31570005 0.10780001 0.40040016 c 0 0.40039992 -0.3542 0.6775999 -0.7545999 0.6775999 c -0.3619001 0 -0.64680004 -0.18479991 -0.86240005 -0.55439997 c -0.1771 -0.30030012 -0.2695 -0.50819993 -0.2695 -0.6314001 c 0 -0.08469987 0.053900003 -0.1308999 0.16169998 -0.1308999 c 0.08469999 0 0.13859999 0.046200037 0.16170001 0.14630008 c 0.11549997 0.37730002 0.37730002 0.9008999 0.78540003 0.9008999 c 0.10780001 0 0.16170001 -0.0769999 0.16170001 -0.23869991 c 0 -0.10780001 -0.046200037 -0.26950002 -0.13859999 -0.4928 c -0.26950002 -0.6853001 -0.4081 -1.1781001 -0.4081 -1.4784 c 0 -0.6699 0.42349994 -0.9933 1.0934 -0.9933 c 0.14629984 0 0.29259992 0.0308 0.43120003 0.0924 c 0.27719998 0.12319999 0.30799985 0.16170001 0.53900003 0.385 c 0.092399836 -0.21559998 0.23099995 -0.35419998 0.42349982 -0.40809998 c 0.13860011 -0.0462 0.26180005 -0.069299996 0.3619001 -0.069299996 c 0.49279976 0 0.7469001 0.5698 0.8701 1.0472 c 0.0230999 0.08470005 0.030799866 0.13089997 0.030799866 0.13859993 c 0 0.08470011 -0.053899765 0.13090003 -0.16169977 0.13090003 c -0.03850031 0 -0.069300175 -0.0076999664 -0.092400074 -0.023100019 c -0.05390024 -0.092399955 -0.092400074 -0.16939998 -0.10010004 -0.23099995 c -0.1308999 -0.5313 -0.3080001 -0.7931 -0.5236001 -0.7931 c -0.14629984 0 -0.22329998 0.1155 -0.22329998 0.34649998 c 0 0.08470005 0.03850007 0.27720004 0.11549997 0.5852 l 0.16170025 0.6853 l 0.1770997 0.66989994 c 0.08470011 0.3311 0.1308999 0.5236001 0.1308999 0.56980014 c 0 0.1539998 -0.1308999 0.26950002 -0.2848997 0.26950002 Z "/>
+        </symbol>
+        <symbol id="g88B53BDDE719A60CE8E8FF27600D6B11" overflow="visible">
+            <path d="M 0 0m 2.9259999 3.2031999 c 0 0.08470011 -0.08469987 0.13090014 -0.25409985 0.13090014 h -0.6776 l 0.2694999 1.0933998 c 0 0.01540041 0.023100138 0.092400074 0.023100138 0.10780001 c 0 0.18480015 -0.092400074 0.27720022 -0.28489995 0.27720022 c -0.23100007 0 -0.3619001 -0.19250011 -0.4158001 -0.45429993 l -0.2464 -1.0241001 h -0.7469 c -0.17709997 0 -0.2695 -0.023100138 -0.2695 -0.19250011 c 0 -0.092399836 0.08470002 -0.13859987 0.2541 -0.13859987 h 0.6776 l -0.43120003 -1.7556 c -0.07699996 -0.30800003 -0.11549997 -0.5005 -0.11549997 -0.5698 c 0 -0.45430005 0.37730002 -0.75460005 0.83159995 -0.75460005 c 0.39270008 0 0.7314999 0.1848 1.0009999 0.5621 c 0.22329998 0.31569996 0.3388002 0.5236 0.3388002 0.6314 c 0 0.08469999 -0.046200037 0.13090003 -0.14630008 0.13090003 c -0.03850007 0 -0.06929994 -0.0077000856 -0.092400074 -0.015400052 c -0.046200037 -0.053900003 -0.0769999 -0.10780001 -0.092399836 -0.14629996 c -0.16940022 -0.37730002 -0.5236001 -0.8855001 -0.9856001 -0.8855001 c -0.15400004 0 -0.23099995 0.1155 -0.23099995 0.33879998 c 0 0.08470005 0.015399933 0.18480003 0.046199918 0.30800003 l 0.53130007 2.1560001 h 0.7469001 c 0.17709994 0 0.26949978 0.03850007 0.26949978 0.20019984 Z "/>
+        </symbol>
+    </defs>
+</svg>

--- a/docs/gallery/11-transfer-function-block-diagram.typ
+++ b/docs/gallery/11-transfer-function-block-diagram.typ
@@ -1,0 +1,68 @@
+#import "@preview/fletcher:0.5.8" as fletcher: diagram, node, edge, cetz
+
+#set page(width: auto, height: auto, margin: 5mm)
+
+#let black-circle(node, extrude, ..extra) = {
+  cetz.draw.circle((0, 0), radius: node.radius/6) 
+}
+
+#let white-circle(node, extrude, ..extra) = {
+  cetz.draw.circle((0, 0), radius: node.radius/3)
+}
+
+#let black-circle-node(in_node) = {
+  node(in_node, shape: black-circle, fill: black, stroke: 1pt, $$)
+}
+
+#let white-circle-node(in_node) = {
+  node(in_node, shape:white-circle, stroke: 1pt, $$)
+}
+
+#let block-node(in_node, content) = {
+  node(in_node, content, shape: rect, stroke: 1pt)
+}
+
+
+
+#diagram(
+  debug: false,
+  spacing: (5mm, 5mm),
+  mark-scale: 60%,
+  edge-stroke: 0.75pt,
+  edge-corner-radius: 0pt,
+  // Nodes Positions
+  let w              = (0,0),
+  let sum_point_1    = (2,0),
+  let branch_point_1 = (3,0),
+  let block_1        = (4,0),
+  let block_2        = (4, 1),
+  let block_3        = (5, 1),
+  let sum_point_2    = (6,0),
+  let i              = (8,0),
+  let w_input        = (8,2),
+  
+  // Node materialization
+  node(w, $omega$),
+  white-circle-node(sum_point_1),
+  black-circle-node(branch_point_1),
+  block-node(block_1, $K_P$),
+  block-node(block_2, $K_I$),
+  block-node(block_3, $1/s$),
+  white-circle-node(sum_point_2),
+  node(i, $I "[A]"$),
+  node(w_input, $omega_(i n p u t)$),
+  
+  // Enclosing box
+  node(enclose: (sum_point_1, (6,1)), stroke: (thickness:1pt, dash: "dashed", ), snap: false, extrude: (10)),
+  
+  // Edges materialization
+  edge(w, sum_point_1, "-|>", label: $+$, label-pos: 90%, label-sep: 0pt, label-size: 7pt),
+  edge(sum_point_1, branch_point_1, "-"),
+  edge(branch_point_1, block_1, "-|>"),
+  edge(branch_point_1, "d,r", "-|>"),
+  edge(block_1, sum_point_2,"-|>", label: $+$, label-pos: 95%, label-sep: 0pt, label-size: 7pt),
+  edge(block_2, block_3,"-|>"),
+  edge(block_3, "r,u", "-|>", label: $+$, label-pos: 97%, label-sep: 0pt, label-size: 7pt),
+  edge(sum_point_2, i, "-|>"),
+  edge(w_input, "l,l,l,l,l,l,u,u", "-|>", label: $-$, label-pos: 99%, label-sep: 1pt, label-size: 7pt),
+)


### PR DESCRIPTION
Hello, recently found this package and decided to give it a try.

I think this package is also great for drawing transfer function block diagrams, so I tried to make one.
Figuring out how to do the summing point and the branching point wasn't straightforward,
so I decided to share how I did it with the pull request.

<img width="473" height="238" alt="transferfunc" src="https://github.com/user-attachments/assets/f170c16c-ad3e-45d4-b7bf-3a79be44e586" />

I was also trying to make the plus and minus signs on the arrows as a custom mark type
but I couldn't figure out how to make separate CetZ drawings (arrow and two lines).
Would probably update if I did figure it out.

