### PR TITLE
Feature: Expose package name

### DIFF
--- a/src/exports.typ
+++ b/src/exports.typ
@@ -8,3 +8,6 @@
 #import "diagram.typ": *
 #import "coords.typ": *
 #import "utils.typ"
+
+// expose name
+#let name = "fletcher"


### PR DESCRIPTION
For easer connection to touying, pls expose the package name, such that we can bind to fletcher automatically.

See: https://github.com/touying-typ/touying/issues/302 for why this benefits touying