### PR TITLE
fix deprecated `plus.circle` symbol

### DIFF
--- a/docs/manual.typ
+++ b/docs/manual.typ
@@ -368,7 +368,7 @@ Avoid importing everything with `*` as many internal functions are also exported
 		     snap: false), // prevent edges snapping to this node
 		edge((0,+1), (1,0), "..|>", corner: left),
 		edge((0,-1), (1,0), "-|>", corner: right),
-		node((1,0), text(white, $ plus.circle $), inset: 2pt, fill: black),
+		node((1,0), text(white, $ plus.o $), inset: 2pt, fill: black),
 		edge("-|>"),
 	)
 	```),
@@ -625,7 +625,7 @@ For example, `<A.north>` and `(name: "A", anchor: "north")` are equivalent coord
 #diagram(
 	node-shape: rect,
 	node(circle(stroke: white, text(white, $Delta$)), name: <A>, fill: navy),
-	node(<A.north-east>, circle(fill: white, radius: 6pt, $ plus.circle $)),
+	node(<A.north-east>, circle(fill: white, radius: 6pt, $ plus.o $)),
 	edge((<A.north-west>, 25%, <A.south-west>), "l,u", "-O"),
 	edge((<A.north-west>, 50%, <A.south-west>), "l,l", "-@"),
 	edge((<A.north-west>, 75%, <A.south-west>), "l,d", "-O"),
@@ -880,8 +880,8 @@ You add or tweak mark styles by modifying `fletcher.MARKS`, as described in @mar
 Marks can be flipped by appending `'` to the name.
 
 #code-example-row(```typ
-#diagram(edge("harpoon'-hook", stroke: 1pt)) 
-#diagram(edge("hook'-harpoon", stroke: 1pt)) 
+#diagram(edge("harpoon'-hook", stroke: 1pt))
+#diagram(edge("hook'-harpoon", stroke: 1pt))
 ```)
 
 If there is a common mark style that you believe should be included with `fletcher` by default, please #link("https://github.com/Jollywatt/typst-fletcher")[open an issue]!

--- a/tests/anchors/test.typ
+++ b/tests/anchors/test.typ
@@ -71,7 +71,7 @@ Node positions depending on other nodes' anchors
 	node((1,1), [Beta], name: <B>, fill: yellow),
 	node(<A.north-east>, $ times.circle $),
 	edge(<A>, "->", auto),
-	node((rel: (0pt, -20pt), to: <A.south>), $ plus.circle $, inset: 0pt, name: <C>),
+	node((rel: (0pt, -20pt), to: <A.south>), $ plus.o $, inset: 0pt, name: <C>),
 	node((rel: (10pt, 0pt), to: <C>), $ f $),
 	edge(
 		<A>,
@@ -92,8 +92,8 @@ Diagram requiring two coordinate resolution passes
 	node(enclose: (<A>, <B>), stroke: yellow, name: <box>, text(yellow)[enclose node\ with anchor])
 
 	// node that depends on the anchors of an enclosing node
-	node(<box.north-east>, $ plus.circle $, name: <D>, stroke: teal)
+	node(<box.north-east>, $ plus.o $, name: <D>, stroke: teal)
 
-	// edge depending on 
+	// edge depending on
 	edge(<D.east>, "->", (rel: (2cm,0cm)), stroke: 1pt + teal)
 })

--- a/tests/node/layer/test.typ
+++ b/tests/node/layer/test.typ
@@ -12,7 +12,7 @@
 	node((0,+1), $G(s)$, fill: white),
 	edge((0,+1), (1,0), "-|>", corner: left),
 	edge((0,-1), (1,0), "..|>", corner: right, layer: -2),
-	node((1,0), text(white, $ plus.circle $), inset: 2pt, fill: black),
+	node((1,0), text(white, $ plus.o $), inset: 2pt, fill: black),
 	edge("-|>"),
 	node(
 		enclose: ((0,+1), (0,-1)),


### PR DESCRIPTION
I just noticed that `plus.circle`, appearing in some example code and tests, no longer works in Typst 0.15; it was deprecated in 0.14(-ish).
I performed a quick find-and-replace. No further checks were done.
Hope this helps! :)
